### PR TITLE
Curated_Lists: update P. Williams affiliations

### DIFF
--- a/Curated_Lists/builders_H0C.tex
+++ b/Curated_Lists/builders_H0C.tex
@@ -158,7 +158,8 @@
 \affiliation{School of Earth and Space Exploration, Arizona State University, Tempe, AZ}
 
 \author{Peter K.~G. Williams}
-\affiliation{Harvard-Smithsonian Center for Astrophysics, Cambridge, MA}
+\affiliation{Center for Astrophysics | Harvard \& Smithsonian, Cambridge, MA}
+\affiliation{American Astronomical Society, Washington, DC}
 
 \author{Haoxuan  Zheng}
 \affiliation{Department of Physics, Massachusetts Institute of Technology, Cambridge, MA}

--- a/Curated_Lists/builders_H0C.txt
+++ b/Curated_Lists/builders_H0C.txt
@@ -32,7 +32,10 @@
 	Nicolas  Fagnoni
 	Nima  Razavi-Ghods
 
-@Harvard-Smithsonian Center for Astrophysics, Cambridge, MA
+@Center for Astrophysics | Harvard & Smithsonian, Cambridge, MA
+	Peter K.~G. Williams
+
+@American Astronomical Society, Washington, DC
 	Peter K.~G. Williams
 
 @Department of Physics, Massachusetts Institute of Technology, Cambridge, MA

--- a/Curated_Lists/builders_H1C.tex
+++ b/Curated_Lists/builders_H1C.tex
@@ -200,7 +200,8 @@
 \affiliation{National Radio Astronomy Observatory, Socorro, NM}
 
 \author{Peter K.~G. Williams}
-\affiliation{Harvard-Smithsonian Center for Astrophysics, Cambridge, MA}
+\affiliation{Center for Astrophysics | Harvard \& Smithsonian, Cambridge, MA}
+\affiliation{American Astronomical Society, Washington, DC}
 
 \author{Haoxuan  Zheng}
 \affiliation{Department of Physics, Massachusetts Institute of Technology, Cambridge, MA}

--- a/Curated_Lists/builders_H1C.txt
+++ b/Curated_Lists/builders_H1C.txt
@@ -45,7 +45,10 @@
 	Bojan Nikolic
 	Kingsley Gale-Sides
 
-@Harvard-Smithsonian Center for Astrophysics, Cambridge, MA
+@Center for Astrophysics | Harvard & Smithsonian, Cambridge, MA
+	Peter K.~G. Williams
+
+@American Astronomical Society, Washington, DC
 	Peter K.~G. Williams
 
 @Department of Physics, Massachusetts Institute of Technology, Cambridge, MA

--- a/Curated_Lists/builders_H2C.tex
+++ b/Curated_Lists/builders_H2C.tex
@@ -207,7 +207,8 @@
 \affiliation{National Radio Astronomy Observatory, Socorro, NM}
 
 \author{Peter K.~G. Williams}
-\affiliation{Harvard-Smithsonian Center for Astrophysics, Cambridge, MA}
+\affiliation{Center for Astrophysics | Harvard \& Smithsonian, Cambridge, MA}
+\affiliation{American Astronomical Society, Washington, DC}
 
 \author{Haoxuan  Zheng}
 \affiliation{Department of Physics, Massachusetts Institute of Technology, Cambridge, MA}

--- a/Curated_Lists/builders_H2C.txt
+++ b/Curated_Lists/builders_H2C.txt
@@ -45,7 +45,10 @@
 	Bojan Nikolic
 	Kingsley Gale-Sides
 
-@Harvard-Smithsonian Center for Astrophysics, Cambridge, MA
+@Center for Astrophysics | Harvard & Smithsonian, Cambridge, MA
+	Peter K.~G. Williams
+
+@American Astronomical Society, Washington, DC
 	Peter K.~G. Williams
 
 @Department of Physics, Massachusetts Institute of Technology, Cambridge, MA


### PR DESCRIPTION
The CfA has changed its name and I am affiliated with AAS too now.

This might actually need testing, depending on whether the organization name I've added to the `.txt` files should use an escaped ampersand (e.g. `\&`) or not!